### PR TITLE
fix debian family service name

### DIFF
--- a/ntp/map.jinja
+++ b/ntp/map.jinja
@@ -2,7 +2,7 @@
     'Debian': {
         'client': 'ntp',
         'server': 'ntpd',
-        'service': 'ntpd',
+        'service': 'ntp',
         'ntpdate': 'ntpdate',
 
         'ntp_conf': '/etc/ntp.conf',


### PR DESCRIPTION
The service in Ubuntu is named ntp.
