### PR TITLE
Configurable init provider for ntp.ng (e.g. for systemd on Gentoo)

### DIFF
--- a/ntp/ng/init.sls
+++ b/ntp/ng/init.sls
@@ -28,6 +28,9 @@ ntpd:
   service.{{ service.get(ntp.settings.ntpd) }}:
     - name: {{ ntp.lookup.service }}
     - enable: {{ ntp.settings.ntpd }}
+    {% if 'provider' in ntp.lookup %}
+    - provider: {{ ntp.lookup.provider }}
+    {% endif %}
     {% if 'package' in ntp.lookup %}
     - require:
       - pkg: ntp

--- a/pillar.example
+++ b/pillar.example
@@ -56,6 +56,7 @@ ntp:
     lookup:
       package: ntp
       service: ntpd
+      provider: systemd
       ntp_conf: /etc/ntp.conf
     # State-specific options
     settings:


### PR DESCRIPTION
Added to the pillar example for ntp.ng a configurable "provider" option for the service definition.
A provider is the same as the grain "init":

    # salt myminion grains.get init
    myminion:
        systemd


The change allows a quick way to set systemd on Gentoo as the init system instead of OpenRC.