### PR TITLE
Restart existing ntpd service on config change

### DIFF
--- a/ntp/ng/init.sls
+++ b/ntp/ng/init.sls
@@ -17,6 +17,8 @@ ntpd_conf:
     - template: jinja
     - context:
       config: {{ ntp.settings.ntp_conf }}
+    - watch_in:
+      - service: {{ ntp.lookup.service }}
     {% if 'package' in ntp.lookup %}
     - require:
       - pkg: ntp


### PR DESCRIPTION
Make existing (deployed before saltstack) `ntpd` service restart on config update
(ng branch)

Previously didn't happened in our existing environment. `ntpd` service was already running, and that is what saltstack answered with previous state file:
```
          ID: ntpd
    Function: service.running
        Name: ntp
      Result: True
     Comment: Service ntp is already enabled, and is running
     Started: 16:37:37.230482
    Duration: 335.92 ms
     Changes:
              ----------
              ntp:
```
...totally ignoring that config actually has been changed with the same highstate.