### PR TITLE
modify ntp/ng/files/ntp.conf to declare any 'tinker' settings first

### DIFF
--- a/ntp/ng/files/ntp.conf
+++ b/ntp/ng/files/ntp.conf
@@ -4,6 +4,10 @@
 #
 # This file is managed by Salt via {{ source }}
 
+{% for value in config.pop('tinker',[]) %}
+tinker {{value}}
+{% endfor -%}
+
 {% for declaration, values in config.items() %}
     {%- for value in values %}
 {{declaration}} {{value}}


### PR DESCRIPTION
Per the ntp documentation (http://doc.ntp.org/4.1.2/miscopt.htm) all 'tinker' directives should reside at the top of ntp.conf. This change makes sure that if any tinker settings have been defined in ntp:ng:settings:ntp_conf they will be inserted into the config file before the rest of the directives.