### PR TITLE
Updating formula so that changes to ntp.conf restart service

### DIFF
--- a/ntp/init.sls
+++ b/ntp/init.sls
@@ -15,5 +15,14 @@ ntp_conf:
     - template: jinja
     - source: {{ ntp_conf_src }}
     - require:
-      - pkg: ntp
+      - pkg: {{ ntp.client }}
 {% endif %}
+
+{% if ntp.ntp_conf -%}
+ntp_running:
+  service.running:
+    - name: {{ ntp.service }}
+    - enable: True
+    - watch:
+      - file: {{ ntp.ntp_conf }}
+{% endif -%}


### PR DESCRIPTION
Hi,

I found that a service restart was required after applying the formula to get NTP using the options specified in /etc/ntp.conf, so I added a watch on the configuration file to trigger a service restart.


Regards,

Mark