### PR TITLE
Fix for ntp to start without error:

### DIFF
--- a/ntp/init.sls
+++ b/ntp/init.sls
@@ -9,6 +9,8 @@ ntp:
 {% set ntp_conf_src = salt['pillar.get']('ntp:ntp_conf') -%}
 
 {% if ntp_conf_src %}
+{% else %}
+{% set ntp_conf_src = 'salt://ntp/ntp.conf' %}
 ntp_conf:
   file.managed:
     - name: {{ ntp.ntp_conf }}

--- a/ntp/init.sls
+++ b/ntp/init.sls
@@ -6,11 +6,7 @@ ntp:
   pkg.installed:
     - name: {{ ntp.client }}
 
-{% if salt['pillar.get']('ntp:ntp_conf') %}
-{% set ntp_conf_src = salt['pillar.get']('ntp:ntp_conf') -%}
-{% else %}
-{% set ntp_conf_src = 'salt://ntp/ntp.conf' %}
-{% endif %}
+{% set ntp_conf_src = salt['pillar.get']('ntp:ntp_conf', 'salt://ntp/ntp.conf') -%}
 
 {% if ntp_conf_src %}
 ntp_conf:

--- a/ntp/init.sls
+++ b/ntp/init.sls
@@ -6,11 +6,13 @@ ntp:
   pkg.installed:
     - name: {{ ntp.client }}
 
+{% if salt['pillar.get']('ntp:ntp_conf') %}
 {% set ntp_conf_src = salt['pillar.get']('ntp:ntp_conf') -%}
-
-{% if ntp_conf_src %}
 {% else %}
 {% set ntp_conf_src = 'salt://ntp/ntp.conf' %}
+{% endif %}
+
+{% if ntp_conf_src %}
 ntp_conf:
   file.managed:
     - name: {{ ntp.ntp_conf }}


### PR DESCRIPTION
Had this error when using the ntp-formula:
Comment: The following requisites were not found

Found that the ntp_conf_src was not being set because it was trying to do a pillar check.
By default the formula should not require a pillar and should just work.
I am just setting src file if a pillar doesn't exist.