### PR TITLE
Add support for HWCLOCK sync when configuring ntp.ng

### DIFF
--- a/ntp/ng/init.sls
+++ b/ntp/ng/init.sls
@@ -40,3 +40,22 @@ ntpd:
     - watch:
       - file: ntpd_conf
 {% endif %}
+
+{#% if 'defaults' in ntp.lookup %#}
+ntpd_defaults:
+  file.managed:
+    - name: {{ ntp.lookup.defaults }}
+    - user: root
+    - group: root
+    - mode: 0664
+    - contents: |
+        # Options for ntpdate
+        OPTIONS="{{ ntp.service.options }}"
+
+        # Number of retries before giving up
+        RETRIES={{ ntp.service.retries }}
+
+        # Set to 'yes' to sync hw clock after successful ntpdate
+        SYNC_HWCLOCK={{ ntp.service.sync_hwclock }}
+        
+{#% endif %#}

--- a/ntp/ng/map.jinja
+++ b/ntp/ng/map.jinja
@@ -17,7 +17,8 @@
         'RedHat': {
             'package': 'ntp',
             'service': 'ntpd',
-            'ntp_conf': '/etc/ntp.conf'
+            'ntp_conf': '/etc/ntp.conf',
+						'defaults': '/etc/sysconfig/ntpdate'
         },
         'Suse': {
             'package': 'ntp',
@@ -40,6 +41,13 @@
             'restrict': ['default noquery nopeer', '127.0.0.1', '::1'],
             'driftfile': [ default_driftfile ]
         }
+		}),
+		'service': { 'options': '-p 2',
+				         'retries': '2',
+				         'sync_hwclock': 'no',
+		           }
 
-    })
-} %}
+    }
+ %}
+
+{% do ntp.service.update( salt['pillar.get']('ntp:ng:service', {})) %}

--- a/pillar.example
+++ b/pillar.example
@@ -53,7 +53,7 @@ ntp:
   ng:
     # OS-specific data that should, in most cases, be handled by map.jinja.
     # It is an optional key and is only used to override defaults.
-    daemon:
+    service:
       # overrides daemon startup options
       options: -p 2
       retries: 2

--- a/pillar.example
+++ b/pillar.example
@@ -53,6 +53,11 @@ ntp:
   ng:
     # OS-specific data that should, in most cases, be handled by map.jinja.
     # It is an optional key and is only used to override defaults.
+    daemon:
+      # overrides daemon startup options
+      options: -p 2
+      retries: 2
+      sync_hwclock: False
     lookup:
       package: ntp
       service: ntpd
@@ -60,6 +65,8 @@ ntp:
       ntp_conf: /etc/ntp.conf
     # State-specific options
     settings:
+		  # if `yes`, set flags to update the hardware after sync
+			sync_hwclock: no
       # If `True`, ntpd will be enabled. Otherwise ntp.conf will be configured
       # but ntpd will not be enabled or started.
       ntpd: True


### PR DESCRIPTION
On RHEL7 the ntpdate service has a flag to set the hardware clock after setting the date.  I added support for changing that to ntp.ng.