### PR TITLE
ng map.jinja fix: properly merge settings: pillar with defaults

### DIFF
--- a/ntp/ng/map.jinja
+++ b/ntp/ng/map.jinja
@@ -40,6 +40,5 @@
             'restrict': ['default noquery nopeer', '127.0.0.1', '::1'],
             'driftfile': [ default_driftfile ]
         }
-
-    })
+    }, merge=True)
 } %}


### PR DESCRIPTION
ntp: ng: settings: pillar completely overrides defaults even when only a single key is defined. Modified map.jinja to merge defaults with pillar.