### PR TITLE
Allow user to set initial_delay when starting service

### DIFF
--- a/ntp/ng/init.sls
+++ b/ntp/ng/init.sls
@@ -30,6 +30,9 @@ ntpd:
   service.{{ service.get(ntp.settings.ntpd) }}:
     - name: {{ ntp.lookup.service }}
     - enable: {{ ntp.settings.ntpd }}
+    {%- if 'init_delay' in ntp.settings %}
+    - init_delay: {{ ntp.settings.init_delay }}
+    {% endif %}
     {% if 'provider' in ntp.lookup %}
     - provider: {{ ntp.lookup.provider }}
     {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -63,6 +63,8 @@ ntp:
       # If `True`, ntpd will be enabled. Otherwise ntp.conf will be configured
       # but ntpd will not be enabled or started.
       ntpd: True
+      # init_delay is used to wait for X seconds for service start
+      init_delay: 5
       # A dictionary of lists, each key corresponds to a conf-file directive in
       # ntp.conf. Eg, the below will compile to:
       #


### PR DESCRIPTION
Hey guys,

In my use case NTPd takes some time to start and this allows me to set a wait time before checking service status when running highstate.

Thanks!