### PR TITLE
Fix fail to compile introduced in previous fix

### DIFF
--- a/ntp/map.jinja
+++ b/ntp/map.jinja
@@ -21,7 +21,7 @@
         'client': 'ntp',
         'server': 'ntpd',
         'service': 'ntpd',
-        'ntpdate':' 'ntpdate',
+        'ntpdate': 'ntpdate',
 
         'ntp_conf': '/etc/ntp.conf',
         'ntpd_conf': '/usr/local/etc/ntpd.conf',


### PR DESCRIPTION
An extra single quote was added in the FreeBSD part. This makes the file compile-able again.