### PR TITLE
salt 2019.2 yaml render compatibility

### DIFF
--- a/ntp/ng/init.sls
+++ b/ntp/ng/init.sls
@@ -16,7 +16,7 @@ ntpd_conf:
     - source: salt://ntp/ng/files/ntp.conf
     - template: jinja
     - context:
-      config: {{ ntp.settings.ntp_conf }}
+      config: {{ ntp.settings.ntp_conf|tojson }}
     - watch_in:
       - service: {{ ntp.lookup.service }}
     {% if 'package' in ntp.lookup %}

--- a/ntp/ng/init.sls
+++ b/ntp/ng/init.sls
@@ -16,7 +16,7 @@ ntpd_conf:
     - source: salt://ntp/ng/files/ntp.conf
     - template: jinja
     - context:
-      config: {{ ntp.settings.ntp_conf|tojson }}
+      config: {{ ntp.settings.ntp_conf|json }}
     - watch_in:
       - service: {{ ntp.lookup.service }}
     {% if 'package' in ntp.lookup %}


### PR DESCRIPTION
Salt 2019.2.0 has Non-Backward-Compatible Change to YAML Renderer, more here: https://docs.saltstack.com/en/latest/topics/releases/2019.2.0.html#non-backward-compatible-change-to-yaml-renderer

Without these changes ntp.ng state is failing:
```
$ salt-call --local state.apply ntp.ng
[CRITICAL] Rendering SLS 'base:ntp.ng' failed: found unexpected ':'
local:
    Data failed to compile:
----------
    Rendering SLS 'base:ntp.ng' failed: found unexpected ':'
```
```
$ salt-call -V
Salt Version:
           Salt: 2019.2.0

Dependency Versions:
           cffi: 1.12.2
       cherrypy: Not Installed
       dateutil: 1.5
      docker-py: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.7.2
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: Not Installed
           Mako: 0.9.1
   msgpack-pure: Not Installed
 msgpack-python: 0.4.6
   mysql-python: 1.2.3
      pycparser: 2.19
       pycrypto: 2.6.1
   pycryptodome: Not Installed
         pygit2: Not Installed
         Python: 2.7.6 (default, Nov 13 2018, 12:45:42)
   python-gnupg: Not Installed
         PyYAML: 3.10
          PyZMQ: 14.0.1
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.0.5

System Versions:
           dist: Ubuntu 14.04 trusty
         locale: ANSI_X3.4-1968
        machine: x86_64
        release: 3.13.0-167-generic
         system: Linux
        version: Ubuntu 14.04 trusty
```
```
pillar.sls
# used in the ntp formula https://github.com/saltstack-formulas/ntp-formula
ntp:
  ng:
    settings:
      ntpd: True
      ntp_conf:
        server: ['0.us.pool.ntp.org', '1.us.pool.ntp.org']
        restrict: ['127.0.0.1', '::1']
        driftfile: ['/var/lib/ntp/ntp.drift']
```