### PR TITLE
Prevent random order of declarations

### DIFF
--- a/ntp/ng/files/ntp.conf
+++ b/ntp/ng/files/ntp.conf
@@ -8,7 +8,7 @@
 tinker {{value}}
 {% endfor -%}
 
-{% for declaration, values in config.items() %}
+{% for declaration, values in config.items() | sort %}
     {%- for value in values %}
 {{declaration}} {{value}}
     {%- endfor %}


### PR DESCRIPTION
when running salt-ssh on a minion with Python 3.5.2.

Tested on:
- master: Salt 2019.2; Python 3.6; FreeBSD 11.2
- minion: Salt 2019.2 (from master); Python 3.5.2; Ubuntu 16.04