### PR TITLE
Make sure ntp service is running and watching conf

### DIFF
--- a/ntp/init.sls
+++ b/ntp/init.sls
@@ -5,6 +5,11 @@
 ntp:
   pkg.installed:
     - name: {{ ntp.client }}
+  service.running:
+    - name: {{ ntp.service }}
+    - enable: True
+    - require:
+      - pkg: {{ ntp.client }}
 
 {% set ntp_conf_src = salt['pillar.get']('ntp:ntp_conf', 'salt://ntp/ntp.conf') -%}
 
@@ -16,5 +21,6 @@ ntp_conf:
     - source: {{ ntp_conf_src }}
     - require:
       - pkg: {{ ntp.client }}
+    - watch_in:
+      - service: {{ ntp.service }}
 {%- endif %}
-


### PR DESCRIPTION
The state was installing ntp, but not making sure it runs. Furthermore I noticed that when I made changes to the used NTP servers, it wouldn't be used, because the service never watches/restarts. I tested that a few times and it fits my needs. I hope other folks will like it, too.