### PR TITLE
test(service): add helper state to run service in containers

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -347,11 +347,16 @@ verifier:
 suites:
   - name: default
     provisioner:
+      dependencies:
+        - name: states
+          path: ./test/salt
       state_top:
         base:
           '*':
             - ntp.ng._mapdata
             - ntp.ng
+          'G@init:systemd and ( G@os:SUSE )':
+            - states.custom_systemd_service
       pillars:
         top.sls:
           base:

--- a/ntp/ng/init.sls
+++ b/ntp/ng/init.sls
@@ -26,15 +26,8 @@ ntpd_conf:
 {% endif %}
 
 {% if 'ntpd' in ntp.settings %}
-{%   set service_state = service.get(ntp.settings.ntpd) %}
-{#   Do not attempt to run the service in a container where the service is configured with #}
-{#   `ConditionVirtualization=!container` or similar (e.g. via. `kitchen-salt`) #}
-{%   if grains.os_family in ['Suse'] and
-        salt['grains.get']('virtual_subtype', '') in ['Docker', 'LXC', 'kubernetes', 'libpod'] %}
-{%     set service_state = 'dead' %}
-{%   endif %}
 ntpd:
-  service.{{ service_state }}:
+  service.{{ service.get(ntp.settings.ntpd) }}:
     - name: {{ ntp.lookup.service }}
     - enable: {{ ntp.settings.ntpd }}
     {%- if 'init_delay' in ntp.settings %}

--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -8,27 +8,13 @@ service_name =
     'ntpd'
   end
 
-control 'ntp service (installed)' do
+control 'ntp service' do
   impact 0.5
   title 'should be installed and enabled'
 
   describe service(service_name) do
     it { should be_installed }
     it { should be_enabled }
-  end
-end
-
-control 'ntp service (running)' do
-  impact 0.5
-  title 'should be running'
-  only_if(
-    'unable to run the service in a container due to its '\
-    '`ConditionVirtualization` setting'
-  ) do
-    platform[:family] != 'suse'
-  end
-
-  describe service(service_name) do
     it { should be_running }
   end
 end

--- a/test/salt/states/custom_systemd_service.sls
+++ b/test/salt/states/custom_systemd_service.sls
@@ -1,0 +1,27 @@
+# This state is used to prepare environment for formula testing
+
+# In distros that have a systemd unit, make sure the service is
+# started even if running in a containerized environment
+
+{%- set sls_config_file = 'ntp.ng.config.file' %}
+{%- set service_file = {
+      'SUSE': '/usr/lib/systemd/system/ntpd.service',
+    }.get(grains.os, '') %}
+
+test-salt-states-custom-systemd-service-file-replace:
+  file.replace:
+    - name: {{ service_file }}
+    - pattern: 'ConditionVirtualization=!container'
+    - repl: ''
+    - show_changes: True
+    - require:
+      - file: ntpd_conf
+
+test-salt-states-custom-systemd-service-cmd-wait:
+  cmd.wait:
+    - name: systemctl daemon-reload
+    - runas: root
+    - watch:
+      - file: test-salt-states-custom-systemd-service-file-replace
+    - require_in:
+      - service: ntpd


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [x] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [x] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

* Semi-automated by https://github.com/myii/ssf-formula/pull/333

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Some distros do not start the service if virtualization is detected, so we force the service to start to test the formula.

Includes a revert for commit 8711b24bb87db443594c1f9bb30da62d7fa4dc37, which is no longer required as a workaround for Kitchen testing due to improved method.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [x] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


