### PR TITLE
issue with current logic in ntp.ng, always true condition + missing ubuntu conf

### DIFF
--- a/ntp/ng/init.sls
+++ b/ntp/ng/init.sls
@@ -26,6 +26,7 @@ ntpd_conf:
 {% endif %}
 
 {% if 'ntpd' in ntp.settings %}
+{% if ntp.settings.ntpd %}
 ntpd:
   service.{{ service.get(ntp.settings.ntpd) }}:
     - name: {{ ntp.lookup.service }}
@@ -42,4 +43,5 @@ ntpd:
     {% endif %}
     - watch:
       - file: ntpd_conf
+{% endif %}
 {% endif %}

--- a/ntp/ng/map.jinja
+++ b/ntp/ng/map.jinja
@@ -14,6 +14,11 @@
             'service': 'ntp',
             'ntp_conf': '/etc/ntp.conf'
         },
+        'Ubuntu': {
+            'package': 'ntp',
+            'service': 'ntp',
+            'ntp_conf': '/etc/ntp.conf'
+        },
         'RedHat': {
             'package': 'ntp',
             'service': 'ntpd',


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->
currently using the ntp.ng formula on a fresh install of ubuntu 20.04
```
----------
          ID: ntp
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 15:49:48.511202
    Duration: 74.385 ms
     Changes:
----------
          ID: ntpd_conf
    Function: file.managed
        Name: /etc/ntp.conf
      Result: True
     Comment: File /etc/ntp.conf is in the correct state
     Started: 15:49:48.586885
    Duration: 53.075 ms
     Changes:
----------
          ID: ntpd
    Function: service.None
        Name: ntp
      Result: False
     Comment: State 'service.None' was not found in SLS 'ntp.ng'
              Reason: 'service.None' is not available.
     Changes:
   ```

This is because right now the existing logic will always run as the mapped data supplied in ntp.ng will always trigger a potentially un-needed (depending on usecase) part of the conf. as this data is being merged with pillar data there is no way to remove the ntp:ng:settings:ntpd key. the variable can be overridden, but the key can not be removed. 
due to this the current logic check is pointless as it is ALWAYS true.

also the above logic is failing due to lack of ubuntu lookup hence the service.None failure. I would have expected being able to disable this service mgmt as there is an if statement around it, however that statement is always true(see above block)

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


